### PR TITLE
Make regular Makefile build 32-bit binary explicitly

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ all:
 
 PROJ = libusb0
 
-CFLAGS = -g -O2 \
+CFLAGS = -g -O2 -m32 \
   -fPIC \
   -Wall \
   -pipe \
@@ -21,7 +21,7 @@ CFLAGS = -g -O2 \
   -gstrict-dwarf \
   -fno-omit-frame-pointer
 
-LDFLAGS =
+LDFLAGS = -m32
 
 OBJS = linux.o error.o usb.o descriptors.o usb-wine.o
 


### PR DESCRIPTION
Hi there,

The previous pull request which enables Aerodrums support adds a 64-bit Makefile. However, the regular Makefile also builds a 64-bit binary for me (probably dependent on the environment, winegcc, ...).
Now that there is an explicit 64-bit makefile, the original makefile should probably allow building a 32-bit binary regardless of environment.
Note that this in my case was also needed in order to make Aerodrums work.

Thanks for this project!